### PR TITLE
Add libxss1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
 	&& wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
 	&& sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
 	&& apt-get update \
-	&& apt-get install -y google-chrome-stable chromium \
+	&& apt-get install -y google-chrome-stable chromium libxss1 \
 	&& apt-get autoremove -y \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* /var/cache/apk/* /var/tmp/* /tmp/* \


### PR DESCRIPTION
This package is required for the magepack generate to not fail with

> chrome-linux/chrome: error while loading shared libraries:
> libXss.so.1: cannot open shared object file

Fixes #4